### PR TITLE
[codex] Add match detail page

### DIFF
--- a/src/app/DTOs/Mappers/gameResponseMapper.ts
+++ b/src/app/DTOs/Mappers/gameResponseMapper.ts
@@ -19,7 +19,11 @@ interface PopulatedRef {
   };
 }
 
-interface GameWithEvents extends Game {
+type GameWithEvents = Omit<Game, "presentPlayers"> & {
+  presentPlayers?: {
+    home?: Array<string | PopulatedRef>;
+    away?: Array<string | PopulatedRef>;
+  };
   events?: Array<{
     _id?: unknown;
     quarter: number;
@@ -32,7 +36,7 @@ interface GameWithEvents extends Game {
     points?: number;
     details?: unknown;
   }>;
-}
+};
 
 export function toGameResponseDto(game: Game): GameResponseDto {
   const gameWithEvents = game as GameWithEvents;
@@ -55,6 +59,10 @@ export function toGameResponseDto(game: Game): GameResponseDto {
     round: game.round,
     score: game.score,
     statistics: game.statistics,
+    presentPlayers: {
+      home: (gameWithEvents.presentPlayers?.home || []).map(toPlayerRef).filter(isDefinedPlayerRef),
+      away: (gameWithEvents.presentPlayers?.away || []).map(toPlayerRef).filter(isDefinedPlayerRef),
+    },
     events: (gameWithEvents.events || []).map(toGameEventResponseDto),
     notes: game.notes,
     createdAt: game.createdAt?.toISOString(),
@@ -115,4 +123,10 @@ function toPlayerRef(player: string | PopulatedRef | undefined): GameEventRespon
 
 function stringifyId(value: unknown): string {
   return value ? value.toString() : "";
+}
+
+function isDefinedPlayerRef(
+  player: ReturnType<typeof toPlayerRef>,
+): player is NonNullable<ReturnType<typeof toPlayerRef>> {
+  return Boolean(player);
 }

--- a/src/app/DTOs/Responses/GameLiveResponseDto.ts
+++ b/src/app/DTOs/Responses/GameLiveResponseDto.ts
@@ -37,10 +37,12 @@ export interface GameLiveResponseDto {
   scheduledDate: string;
   actualStartTime?: string;
   actualEndTime?: string;
+  week?: number;
+  round?: string;
   score: GameScore;
   events: GameEventResponseDto[];
   presentPlayers?: {
-    home: string[];
-    away: string[];
+    home: Array<PlayerSummaryResponseDto | string>;
+    away: Array<PlayerSummaryResponseDto | string>;
   };
 }

--- a/src/app/DTOs/Responses/GameResponseDto.ts
+++ b/src/app/DTOs/Responses/GameResponseDto.ts
@@ -1,6 +1,7 @@
 import type { GameStatus, GameStatistics } from "@/entities/Game";
 import type { GameScore } from "@/entities/valueObjects/Score";
 import type { GameEventResponseDto } from "./GameLiveResponseDto";
+import type { PlayerSummaryResponseDto } from "./PlayerSummaryResponseDto";
 
 export interface GameResponseDto {
   _id?: string;
@@ -20,6 +21,10 @@ export interface GameResponseDto {
   round?: string;
   score: GameScore;
   statistics: GameStatistics;
+  presentPlayers?: {
+    home: Array<PlayerSummaryResponseDto | string>;
+    away: Array<PlayerSummaryResponseDto | string>;
+  };
   events: GameEventResponseDto[];
   notes?: string;
   createdAt?: string;

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -16,7 +16,7 @@ type PlayerRef = PlayerSummaryResponseDto | string;
 
 const SCORING_EVENT_LABELS: Partial<Record<GameEventType, string>> = {
   touchdown: "Touchdown",
-  extra_point: "Conversión",
+  extra_point: "Punto extra",
   field_goal: "Field goal",
   safety: "Safety",
   pick_six: "Pick six",

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import Avatar from "@/components/Avatar";
+import ErrorMessage from "@/components/ErrorMessage";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import Tag from "@/components/Tag";
+import { useAuth } from "@/hooks/useAuth";
+import type { ApiResponse, GameApiResponse, GameEventType, PlayerApiResponse } from "@/types";
+import type { PlayerSummaryResponseDto, TeamSummaryResponseDto } from "@/app/DTOs";
+
+type TeamSide = "home" | "away";
+type PlayerRef = PlayerSummaryResponseDto | string;
+
+const SCORING_EVENT_LABELS: Partial<Record<GameEventType, string>> = {
+  touchdown: "Touchdown",
+  extra_point: "Conversión",
+  field_goal: "Field goal",
+  safety: "Safety",
+  pick_six: "Pick six",
+};
+
+const STATUS_COPY: Record<GameApiResponse["status"], { label: string; type: "info" | "warning" | "success" | "error" }> = {
+  scheduled: { label: "Pendiente", type: "info" },
+  in_progress: { label: "En curso", type: "success" },
+  completed: { label: "Finalizado", type: "success" },
+  postponed: { label: "Pospuesto", type: "warning" },
+  cancelled: { label: "Cancelado", type: "error" },
+};
+
+function getTeamName(team: TeamSummaryResponseDto | string | null | undefined, fallback: string) {
+  return typeof team === "string" || !team ? fallback : team.name;
+}
+
+function getTeamId(team: TeamSummaryResponseDto | string | null | undefined) {
+  return typeof team === "string" ? team : team?._id || "";
+}
+
+function getTeamColor(team: TeamSummaryResponseDto | string | null | undefined) {
+  return typeof team === "string" || !team ? "#6b7280" : team.colors.primary || "#6b7280";
+}
+
+function getTeamFallback(team: TeamSummaryResponseDto | string | null | undefined, fallback: string) {
+  if (typeof team === "string" || !team) return fallback;
+  return (team.shortName || team.name.slice(0, 2)).toUpperCase();
+}
+
+function getPlayerId(player: PlayerRef) {
+  return typeof player === "string" ? player : player._id;
+}
+
+function getPlayerName(player: PlayerRef | undefined, fallback = "Jugador") {
+  if (!player) return fallback;
+  if (typeof player === "string") return fallback;
+  const jersey = player.jerseyNumber != null ? `#${player.jerseyNumber} ` : "";
+  return `${jersey}${player.firstName} ${player.lastName}`;
+}
+
+function sortPlayers(players: PlayerSummaryResponseDto[]) {
+  return [...players].sort((left, right) => {
+    const leftNumber = left.jerseyNumber ?? Number.MAX_SAFE_INTEGER;
+    const rightNumber = right.jerseyNumber ?? Number.MAX_SAFE_INTEGER;
+
+    if (leftNumber !== rightNumber) return leftNumber - rightNumber;
+
+    return `${left.firstName} ${left.lastName}`.localeCompare(`${right.firstName} ${right.lastName}`, "es", {
+      sensitivity: "base",
+    });
+  });
+}
+
+function formatDateTime(date: string) {
+  return new Date(date).toLocaleString("es-ES", {
+    weekday: "long",
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getScoringLabel(type: GameEventType, points?: number) {
+  const label = SCORING_EVENT_LABELS[type] || "Anotación";
+  return points ? `${label} +${points}` : label;
+}
+
+function getScoringBadgeClass(type: GameEventType) {
+  const classes: Partial<Record<GameEventType, string>> = {
+    touchdown: "bg-blue-100 text-blue-800 ring-blue-200",
+    pick_six: "bg-purple-100 text-purple-800 ring-purple-200",
+    extra_point: "bg-emerald-100 text-emerald-800 ring-emerald-200",
+    safety: "bg-amber-100 text-amber-900 ring-amber-200",
+    field_goal: "bg-sky-100 text-sky-800 ring-sky-200",
+  };
+
+  return classes[type] || "bg-gray-100 text-gray-700 ring-gray-200";
+}
+
+export default function MatchPage() {
+  const params = useParams();
+  const gameId = params?.id as string;
+  const { user } = useAuth();
+  const canManageGame = user?.role === "admin";
+
+  const [game, setGame] = useState<GameApiResponse | null>(null);
+  const [homeRoster, setHomeRoster] = useState<PlayerApiResponse[]>([]);
+  const [awayRoster, setAwayRoster] = useState<PlayerApiResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTeamPlayers = useCallback(async (teamId: string) => {
+    if (!teamId) return [];
+
+    const response = await fetch(`/api/players?team=${teamId}&limit=100`);
+    const data: ApiResponse<PlayerApiResponse[]> = await response.json();
+
+    if (!response.ok || !data.success || !data.data) {
+      return [];
+    }
+
+    return data.data.filter((player) => player.status === "active");
+  }, []);
+
+  const fetchMatch = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch(`/api/games/${gameId}`);
+      const data: ApiResponse<GameApiResponse> = await response.json();
+
+      if (!response.ok || !data.success || !data.data) {
+        setError(data.message || "No se pudo cargar el partido");
+        return;
+      }
+
+      setGame(data.data);
+
+      const [homePlayers, awayPlayers] = await Promise.all([
+        fetchTeamPlayers(getTeamId(data.data.homeTeam)),
+        fetchTeamPlayers(getTeamId(data.data.awayTeam)),
+      ]);
+
+      setHomeRoster(homePlayers);
+      setAwayRoster(awayPlayers);
+    } catch {
+      setError("Error de conexión. Intenta de nuevo.");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchTeamPlayers, gameId]);
+
+  useEffect(() => {
+    fetchMatch();
+  }, [fetchMatch]);
+
+  const rosterById = useMemo(() => {
+    const entries = [...homeRoster, ...awayRoster].map((player) => [player._id, player] as const);
+    return new Map(entries);
+  }, [awayRoster, homeRoster]);
+
+  const presentPlayers = useMemo(() => {
+    const buildSide = (side: TeamSide, roster: PlayerApiResponse[]) => {
+      const savedPresent = game?.presentPlayers?.[side] || [];
+
+      if (savedPresent.length > 0) {
+        return sortPlayers(
+          savedPresent.map((player) => {
+            if (typeof player !== "string") return player;
+            return rosterById.get(player) || {
+              _id: player,
+              firstName: "Jugador",
+              lastName: "",
+              jerseyNumber: null,
+              position: "",
+              status: "active",
+            };
+          }),
+        );
+      }
+
+      if (game?.status === "scheduled") {
+        return sortPlayers(roster);
+      }
+
+      return [];
+    };
+
+    return {
+      home: buildSide("home", homeRoster),
+      away: buildSide("away", awayRoster),
+    };
+  }, [game?.presentPlayers, game?.status, homeRoster, awayRoster, rosterById]);
+
+  const scorers = useMemo(() => {
+    if (!game?.events) return [];
+
+    const grouped = new Map<
+      string,
+      {
+        player: PlayerRef;
+        team: TeamSummaryResponseDto | string;
+        points: number;
+        plays: Array<{
+          quarter: number;
+          type: GameEventType;
+          points: number;
+        }>;
+      }
+    >();
+
+    game.events.forEach((event) => {
+      if (!event.player || !event.points || event.points <= 0) return;
+
+      const playerId = getPlayerId(event.player);
+      const current = grouped.get(playerId) || {
+        player: event.player,
+        team: event.team,
+        points: 0,
+        plays: [],
+      };
+
+      current.points += event.points;
+      current.plays.push({
+        quarter: event.quarter,
+        type: event.type,
+        points: event.points,
+      });
+      grouped.set(playerId, current);
+    });
+
+    return [...grouped.values()].sort((left, right) => right.points - left.points);
+  }, [game?.events]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error || !game) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10">
+        <ErrorMessage message={error || "Partido no encontrado"} onRetry={fetchMatch} />
+        <Link href="/games" className="mt-4 inline-flex text-sm font-semibold text-green-700 hover:text-green-800">
+          Volver a partidos
+        </Link>
+      </div>
+    );
+  }
+
+  const status = STATUS_COPY[game.status];
+  const homeName = getTeamName(game.homeTeam, "Equipo Local");
+  const awayName = getTeamName(game.awayTeam, "Equipo Visitante");
+  const isPending = game.status === "scheduled";
+
+  const renderPlayerList = (side: TeamSide, players: PlayerSummaryResponseDto[]) => {
+    const team = side === "home" ? game.homeTeam : game.awayTeam;
+    const emptyMessage = isPending
+      ? "No hay jugadores activos registrados."
+      : "No hay presentes registrados para este equipo.";
+
+    return (
+      <section className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-200">
+        <div className="flex items-center gap-3 border-b border-gray-100 p-4">
+          <Avatar
+            imageUrl={typeof team === "string" ? undefined : team?.logo}
+            alt={getTeamName(team, side === "home" ? "Local" : "Visitante")}
+            fallback={getTeamFallback(team, side === "home" ? "LO" : "VI")}
+            backgroundColor={getTeamColor(team)}
+            size="sm"
+          />
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-bold text-gray-900">{getTeamName(team, "Equipo")}</h2>
+            <p className="text-sm text-gray-500">{isPending ? "Plantel disponible" : "Presentes"}</p>
+          </div>
+          <span className="ml-auto rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700">
+            {players.length}
+          </span>
+        </div>
+
+        <div className="divide-y divide-gray-100">
+          {players.length > 0 ? (
+            players.map((player) => (
+              <div key={player._id} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="truncate font-semibold text-gray-900">
+                    {player.jerseyNumber != null ? `#${player.jerseyNumber} ` : ""}
+                    {player.firstName} {player.lastName}
+                  </p>
+                  <p className="text-sm text-gray-500">{player.position || "Sin posición"}</p>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="px-4 py-8 text-center text-sm text-gray-500">{emptyMessage}</div>
+          )}
+        </div>
+      </section>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-5 flex items-center justify-between gap-3">
+          <Link href="/games" className="text-sm font-semibold text-gray-600 hover:text-gray-900">
+            Volver a partidos
+          </Link>
+          <Tag label={status.label} type={status.type} />
+        </div>
+
+        {canManageGame && (
+          <div className="mb-5 flex flex-wrap justify-end gap-2">
+            {(game.status === "scheduled" || game.status === "in_progress") && (
+              <Link
+                href={`/games/${game._id}/live`}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-blue-700"
+              >
+                Live Match
+              </Link>
+            )}
+            <Link
+              href={`/games?edit=${game._id}`}
+              className="rounded-md bg-green-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-green-700"
+            >
+              Editar partido
+            </Link>
+          </div>
+        )}
+
+        <header className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200 sm:p-6">
+          <div className="mb-4 text-center text-sm text-gray-500">
+            <span>{typeof game.tournament === "string" ? "Torneo" : game.tournament?.name}</span>
+            <span className="mx-2 text-gray-300">·</span>
+            <span>{typeof game.division === "string" ? "División" : game.division?.name}</span>
+          </div>
+
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 sm:gap-6">
+            <div className="min-w-0 text-center sm:text-right">
+              <div className="mb-2 flex justify-center sm:justify-end">
+                <Avatar
+                  imageUrl={typeof game.homeTeam === "string" ? undefined : game.homeTeam?.logo}
+                  alt={homeName}
+                  fallback={getTeamFallback(game.homeTeam, "LO")}
+                  backgroundColor={getTeamColor(game.homeTeam)}
+                  size="md"
+                />
+              </div>
+              <h1 className="break-words text-base font-black text-gray-900 sm:text-2xl">{homeName}</h1>
+            </div>
+
+            <div className="text-center">
+              {game.status === "scheduled" ? (
+                <div className="text-2xl font-black text-gray-400">VS</div>
+              ) : (
+                <div className="text-4xl font-black text-gray-900 sm:text-6xl">
+                  {game.score.home.total} - {game.score.away.total}
+                </div>
+              )}
+            </div>
+
+            <div className="min-w-0 text-center sm:text-left">
+              <div className="mb-2 flex justify-center sm:justify-start">
+                <Avatar
+                  imageUrl={typeof game.awayTeam === "string" ? undefined : game.awayTeam?.logo}
+                  alt={awayName}
+                  fallback={getTeamFallback(game.awayTeam, "VI")}
+                  backgroundColor={getTeamColor(game.awayTeam)}
+                  size="md"
+                />
+              </div>
+              <h1 className="break-words text-base font-black text-gray-900 sm:text-2xl">{awayName}</h1>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-2 text-center text-sm text-gray-600 sm:grid-cols-3">
+            <div>{formatDateTime(game.scheduledDate)}</div>
+            <div>{game.venue?.name}</div>
+            <div>{game.week ? `Semana ${game.week}` : game.round || "Fecha por definir"}</div>
+          </div>
+        </header>
+
+        <main className="mt-6 grid gap-6 lg:grid-cols-[1fr_360px]">
+          <div className="grid gap-6 md:grid-cols-2">
+            {renderPlayerList("home", presentPlayers.home)}
+            {renderPlayerList("away", presentPlayers.away)}
+          </div>
+
+          <section className="rounded-lg bg-white shadow-sm ring-1 ring-gray-200">
+            <div className="border-b border-gray-100 p-4">
+              <h2 className="text-base font-bold text-gray-900">Anotadores</h2>
+              <p className="text-sm text-gray-500">
+                {game.status === "scheduled" ? "Aún no hay anotaciones." : `${scorers.length} jugadores con puntos`}
+              </p>
+            </div>
+
+            <div className="divide-y divide-gray-100">
+              {scorers.length > 0 ? (
+                scorers.map((scorer) => (
+                  <div key={getPlayerId(scorer.player)} className="p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-bold text-gray-900">{getPlayerName(scorer.player)}</p>
+                        <p className="text-sm text-gray-500">{getTeamName(scorer.team, "Equipo")}</p>
+                      </div>
+                      <span className="rounded-full bg-green-100 px-3 py-1 text-sm font-black text-green-800">
+                        {scorer.points} pts
+                      </span>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {scorer.plays.map((play, index) => (
+                        <span
+                          key={`${play.quarter}-${play.type}-${play.points}-${index}`}
+                          className="inline-flex items-center overflow-hidden rounded-full text-xs font-bold ring-1"
+                        >
+                          <span className="bg-gray-900 px-2 py-1 text-white">
+                            {play.quarter === 5 ? "ET" : `${play.quarter}T`}
+                          </span>
+                          <span className={`px-2.5 py-1 ${getScoringBadgeClass(play.type)}`}>
+                            {getScoringLabel(play.type, play.points)}
+                          </span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="px-4 py-10 text-center text-sm text-gray-500">
+                  {isPending ? "El partido todavía está pendiente." : "No hay eventos de anotación registrados."}
+                </div>
+              )}
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -167,6 +167,7 @@ export default function GamesPage() {
   const [form, setForm] = useState<GameFormState>(INITIAL_FORM);
   const [showForm, setShowForm] = useState(false);
   const [editingGame, setEditingGame] = useState<Game | null>(null);
+  const [handledEditGameId, setHandledEditGameId] = useState<string | null>(null);
 
   const [tournaments, setTournaments] = useState<TournamentOption[]>([]);
   const [divisions, setDivisions] = useState<DivisionOption[]>([]);
@@ -336,7 +337,7 @@ export default function GamesPage() {
     setShowForm(true);
   };
 
-  const openEditForm = async (game: Game) => {
+  const openEditForm = useCallback(async (game: Game) => {
     if (!canManageGames) return;
 
     const tournamentId = getRefId(game.tournament);
@@ -367,7 +368,7 @@ export default function GamesPage() {
     setEditingGame(game);
     setFormError(null);
     setShowForm(true);
-  };
+  }, [canManageGames, fetchTeamsForDivision]);
 
   const closeForm = () => {
     setShowForm(false);
@@ -375,6 +376,37 @@ export default function GamesPage() {
     setEditingGame(null);
     setFormError(null);
   };
+
+  useEffect(() => {
+    const editGameId = new URLSearchParams(window.location.search).get("edit");
+
+    if (!canManageGames || !editGameId || handledEditGameId === editGameId) {
+      return;
+    }
+
+    const openRequestedGame = async () => {
+      const localGame = games.find((game) => game._id === editGameId);
+      if (localGame) {
+        setHandledEditGameId(editGameId);
+        await openEditForm(localGame);
+        return;
+      }
+
+      try {
+        const response = await fetch(`/api/games/${editGameId}`);
+        const data: ApiResponse<Game> = await response.json();
+
+        if (response.ok && data.success && data.data) {
+          setHandledEditGameId(editGameId);
+          await openEditForm(data.data);
+        }
+      } catch {
+        // No bloquear la página si el deep link de edición no carga.
+      }
+    };
+
+    void openRequestedGame();
+  }, [canManageGames, games, handledEditGameId, openEditForm]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -942,7 +974,12 @@ export default function GamesPage() {
 
       <div className="space-y-4">
         {games.map((game) => (
-          <div key={game._id} className="bg-white rounded-lg shadow-md p-4 sm:p-6 hover:shadow-lg transition-shadow">
+          <Link
+            key={game._id}
+            href={`/games/${game._id}`}
+            className="block rounded-lg bg-white p-4 shadow-md transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 sm:p-6"
+            aria-label={`Ver match ${game.homeTeam?.name || "TBD"} vs ${game.awayTeam?.name || "TBD"}`}
+          >
             <div className="sm:hidden">
               <div className="flex items-start justify-between gap-3">
                 <div className="text-sm text-gray-700 font-medium break-words">{game.venue.name}</div>
@@ -989,24 +1026,6 @@ export default function GamesPage() {
                 {game.round ? ` · ${game.round}` : ""}
               </div>
 
-              {canManageGames && (
-                <div className="mt-4 grid gap-2">
-                  {(game.status === "scheduled" || game.status === "in_progress") && (
-                    <Link
-                      href={`/games/${game._id}/live`}
-                      className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium text-center transition-colors"
-                    >
-                      Live Match
-                    </Link>
-                  )}
-                  <button
-                    onClick={() => openEditForm(game)}
-                    className="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
-                  >
-                    Editar
-                  </button>
-                </div>
-              )}
             </div>
 
             <div className="hidden sm:block">
@@ -1079,27 +1098,9 @@ export default function GamesPage() {
                   </div>
                 </div>
 
-                {canManageGames && (
-                  <div className="mt-4 lg:mt-0 lg:ml-6 flex gap-3">
-                    {(game.status === "scheduled" || game.status === "in_progress") && (
-                      <Link
-                        href={`/games/${game._id}/live`}
-                        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
-                      >
-                        Live Match
-                      </Link>
-                    )}
-                    <button
-                      onClick={() => openEditForm(game)}
-                      className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
-                    >
-                      Editar
-                    </button>
-                  </div>
-                )}
               </div>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
 

--- a/src/entities/Game.ts
+++ b/src/entities/Game.ts
@@ -38,6 +38,11 @@ export interface GameStatistics {
   away: TeamStatistics;
 }
 
+export interface GamePresentPlayers {
+  home: string[];
+  away: string[];
+}
+
 /**
  * Entity: Game (Partido)
  * Aggregate Root - Entidad más compleja del dominio
@@ -56,6 +61,7 @@ export class Game extends AggregateRoot {
   public readonly round?: string;
   public readonly score: GameScore;
   public readonly statistics: GameStatistics;
+  public readonly presentPlayers?: GamePresentPlayers;
   public readonly notes?: string;
 
   constructor(
@@ -68,6 +74,7 @@ export class Game extends AggregateRoot {
     awayTeam: string | null = null,
     score?: GameScore,
     statistics?: GameStatistics,
+    presentPlayers?: GamePresentPlayers,
     week?: number,
     round?: string,
     actualStartTime?: Date,
@@ -94,6 +101,7 @@ export class Game extends AggregateRoot {
       home: TeamStatistics.empty(),
       away: TeamStatistics.empty(),
     };
+    this.presentPlayers = presentPlayers;
     this.notes = notes;
   }
 
@@ -150,6 +158,7 @@ export class Game extends AggregateRoot {
       this.awayTeam,
       this.score,
       this.statistics,
+      this.presentPlayers,
       this.week,
       this.round,
       new Date(),
@@ -179,6 +188,7 @@ export class Game extends AggregateRoot {
       this.awayTeam,
       this.score,
       this.statistics,
+      this.presentPlayers,
       this.week,
       this.round,
       this.actualStartTime,

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -66,6 +66,14 @@ const GameStatisticsSchema = new Schema({
   away: { type: TeamGameStatsSchema, required: true },
 });
 
+const PresentPlayersSchema = new Schema(
+  {
+    home: [{ type: Schema.Types.ObjectId, ref: "Player" }],
+    away: [{ type: Schema.Types.ObjectId, ref: "Player" }],
+  },
+  { _id: false },
+);
+
 const GameEventSchema = new Schema({
   quarter: { type: Number, required: true, min: 1, max: 5 },
   time: { type: String }, // MM:SS format
@@ -118,6 +126,7 @@ const GameSchema = new Schema(
     weather: { type: WeatherConditionsSchema },
     score: { type: GameScoreSchema, required: true },
     statistics: { type: GameStatisticsSchema, required: true },
+    presentPlayers: { type: PresentPlayersSchema, default: () => ({ home: [], away: [] }) },
     events: [{ type: GameEventSchema }],
     notes: { type: String, trim: true },
   },

--- a/src/repositories/mongodb/MongoGameRepository.ts
+++ b/src/repositories/mongodb/MongoGameRepository.ts
@@ -12,6 +12,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -23,6 +25,8 @@ export class MongoGameRepository implements IGameRepository {
     const docs = await GameModel.find(filters || {})
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -148,6 +152,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -190,6 +196,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -232,6 +240,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -256,6 +266,7 @@ export class MongoGameRepository implements IGameRepository {
         $set: {
           status: "in_progress",
           actualStartTime: new Date(),
+          presentPlayers,
         },
       },
       { new: true },
@@ -264,6 +275,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -275,9 +288,6 @@ export class MongoGameRepository implements IGameRepository {
       }
       throw new Error("Solo se pueden iniciar partidos programados");
     }
-
-    // El esquema actual no persiste presentPlayers, pero se valida en servicio.
-    void presentPlayers;
 
     return doc;
   }
@@ -294,6 +304,8 @@ export class MongoGameRepository implements IGameRepository {
       .populate("awayTeam")
       .populate("tournament")
       .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();

--- a/src/services/backend/GameService.ts
+++ b/src/services/backend/GameService.ts
@@ -83,6 +83,7 @@ export class GameService {
       data.awayTeam,
       GameScore.zero(),
       undefined,
+      undefined,
       data.week,
       data.round,
     );
@@ -512,6 +513,7 @@ export class GameService {
       data.awayTeam || this.getReferenceId(game.awayTeam),
       normalizedScore,
       game.statistics,
+      game.presentPlayers,
       data.week !== undefined ? data.week : game.week,
       data.round || game.round,
       game.actualStartTime,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,6 +177,10 @@ export interface Game {
   weather?: WeatherConditions;
   score: GameScore;
   statistics: GameStatistics;
+  presentPlayers?: {
+    home: string[];
+    away: string[];
+  };
   events: GameEvent[];
   notes?: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary

Adds a match detail page at /games/[id] so users can open a scheduled, in-progress, or completed match directly from the games list.

## Changes

- Makes each game card in /games clickable instead of showing visible match/admin buttons inside the card.
- Adds a dedicated match page with matchup details, score, present players, and scorers.
- Shows scoring play types as badges in the scorers section.
- Persists presentPlayers when a match is started from Live Match and returns them in game DTOs.
- Moves admin actions into the individual match page, including Live Match and edit access.

## Validation

- Ran npm run build successfully.
- Verified in the in-app browser that /games no longer shows Ver Match or Abrir match and has no Next.js error overlay.

## Notes

Existing completed matches from before this change may not have historical present-player data because it was not previously persisted.