### PR TITLE
Add team matches tab and improve match card display

### DIFF
--- a/src/app/DTOs/Mappers/gameResponseMapper.ts
+++ b/src/app/DTOs/Mappers/gameResponseMapper.ts
@@ -6,6 +6,8 @@ interface PopulatedRef {
   _id?: unknown;
   id?: unknown;
   name?: string;
+  category?: string;
+  year?: number;
   firstName?: string;
   lastName?: string;
   jerseyNumber?: number | null;
@@ -43,8 +45,8 @@ export function toGameResponseDto(game: Game): GameResponseDto {
 
   return {
     _id: game.id,
-    tournament: game.tournament,
-    division: game.division,
+    tournament: toTournamentRef(gameWithEvents.tournament),
+    division: toDivisionRef(gameWithEvents.division),
     homeTeam: game.homeTeam,
     awayTeam: game.awayTeam,
     venue: {
@@ -67,6 +69,30 @@ export function toGameResponseDto(game: Game): GameResponseDto {
     notes: game.notes,
     createdAt: game.createdAt?.toISOString(),
     updatedAt: game.updatedAt?.toISOString(),
+  };
+}
+
+function toTournamentRef(tournament: string | PopulatedRef): GameResponseDto["tournament"] {
+  if (typeof tournament === "string") {
+    return tournament;
+  }
+
+  return {
+    _id: stringifyId(tournament._id || tournament.id),
+    name: tournament.name || "Torneo",
+    year: tournament.year || new Date().getFullYear(),
+  };
+}
+
+function toDivisionRef(division: string | PopulatedRef): GameResponseDto["division"] {
+  if (typeof division === "string") {
+    return division;
+  }
+
+  return {
+    _id: stringifyId(division._id || division.id),
+    name: division.name || "División",
+    category: division.category || "",
   };
 }
 

--- a/src/app/DTOs/Responses/GameResponseDto.ts
+++ b/src/app/DTOs/Responses/GameResponseDto.ts
@@ -5,8 +5,20 @@ import type { PlayerSummaryResponseDto } from "./PlayerSummaryResponseDto";
 
 export interface GameResponseDto {
   _id?: string;
-  tournament: string;
-  division: string;
+  tournament:
+    | string
+    | {
+        _id: string;
+        name: string;
+        year: number;
+      };
+  division:
+    | string
+    | {
+        _id: string;
+        name: string;
+        category: string;
+      };
   homeTeam: string | null;
   awayTeam: string | null;
   venue: {

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -139,6 +139,18 @@ function getTeamDisplayName(value: unknown): string {
   return "TBD";
 }
 
+function getDivisionDisplayName(division: DivisionOption | string | null | undefined): string {
+  if (!division || typeof division === "string") return "División";
+
+  const categoryLabel: Record<string, string> = {
+    masculino: "Masculino",
+    femenino: "Femenino",
+    mixto: "Mixto",
+  };
+
+  return division.category ? categoryLabel[division.category] || division.category : division.name || "División";
+}
+
 export default function GamesPage() {
   const { user } = useAuth();
   const canManageGames = user?.role === "admin";
@@ -1022,7 +1034,7 @@ export default function GamesPage() {
               </div>
 
               <div className="mt-3 text-xs text-gray-500 text-center">
-                {game.week ? `Semana ${game.week}` : "Sin semana"} · {game.division.name}
+                {game.week ? `Semana ${game.week}` : "Sin semana"} · {getDivisionDisplayName(game.division)}
                 {game.round ? ` · ${game.round}` : ""}
               </div>
 
@@ -1035,7 +1047,7 @@ export default function GamesPage() {
                     <div className="flex items-center space-x-2">
                       {getStatusTag(game.status)}
                       <span className="text-sm text-gray-500">
-                        {game.week ? `Semana ${game.week}` : "Sin semana"} - {game.division.name}
+                        {game.week ? `Semana ${game.week}` : "Sin semana"} - {getDivisionDisplayName(game.division)}
                         {game.round ? ` - ${game.round}` : ""}
                       </span>
                     </div>

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -481,7 +481,15 @@ export default function TeamViewerPage() {
   };
 
   const getDivisionName = (game: TeamGame) => {
-    return typeof game.division === "string" ? "División" : game.division.name || "División";
+    if (typeof game.division === "string") return "División";
+
+    const categoryLabel: Record<string, string> = {
+      masculino: "Masculino",
+      femenino: "Femenino",
+      mixto: "Mixto",
+    };
+
+    return game.division.category ? categoryLabel[game.division.category] || game.division.category : game.division.name || "División";
   };
 
   const renderGameCard = (game: TeamGame) => (

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -458,15 +458,6 @@ export default function TeamViewerPage() {
     />
   );
 
-  const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString("es-ES", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
   const formatTime = (date: string) => {
     return new Date(date).toLocaleTimeString("es-ES", {
       hour: "2-digit",
@@ -497,124 +488,47 @@ export default function TeamViewerPage() {
     <Link
       key={game._id}
       href={`/games/${game._id}`}
-      className="block rounded-lg bg-white p-4 shadow-md transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 sm:p-6"
+      className="block rounded-lg bg-white p-4 shadow-md transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
       aria-label={`Ver match ${getTeamDisplayName(game.homeTeam)} vs ${getTeamDisplayName(game.awayTeam)}`}
     >
-      <div className="sm:hidden">
-        <div className="flex items-start justify-between gap-3">
-          <div className="text-sm font-medium text-gray-700 break-words">{game.venue.name}</div>
-          <div className="text-xs text-gray-500 whitespace-nowrap">{formatDateTimeCompact(game.scheduledDate)}</div>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-gray-700">{game.venue.name}</div>
+          <div className="mt-1 line-clamp-2 text-xs text-gray-500">{game.venue.address}</div>
+        </div>
+        <div className="shrink-0 text-right text-xs text-gray-500">{formatDateTimeCompact(game.scheduledDate)}</div>
+      </div>
+
+      <div className="mt-4 flex justify-center">{getGameStatusTag(game.status)}</div>
+
+      <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+        <div className="min-w-0 text-center">
+          <div className="mb-2 flex justify-center">{renderGameTeamAvatar(game.homeTeam, "sm")}</div>
+          <div className="truncate text-sm font-bold text-gray-900">{getTeamDisplayName(game.homeTeam)}</div>
         </div>
 
-        <div className="mt-1 text-xs text-gray-500 break-words">{game.venue.address}</div>
-
-        <div className="mt-3 flex justify-center">{getGameStatusTag(game.status)}</div>
-
-        <div className="mt-3 flex items-center justify-between gap-2">
-          <div className="w-[36%] flex flex-col items-center text-center">
-            {renderGameTeamAvatar(game.homeTeam, "sm")}
-            <div className="mt-2 text-xs font-semibold text-gray-900 leading-tight break-words w-full">
-              {getTeamDisplayName(game.homeTeam)}
+        <div className="text-center">
+          {game.status === "completed" || game.status === "in_progress" ? (
+            <div className="text-2xl font-bold leading-none text-blue-900">
+              {game.score.home.total}:{game.score.away.total}
             </div>
-          </div>
-
-          <div className="w-[28%] text-center">
-            {game.status === "completed" || game.status === "in_progress" ? (
-              <div className="text-4xl font-bold text-blue-900 leading-none">
-                {game.score.home.total}:{game.score.away.total}
-              </div>
-            ) : (
-              <div>
-                <div className="text-base font-semibold text-gray-500">vs</div>
-                <div className="text-xs text-gray-400">{formatTime(game.scheduledDate)}</div>
-              </div>
-            )}
-          </div>
-
-          <div className="w-[36%] flex flex-col items-center text-center">
-            {renderGameTeamAvatar(game.awayTeam, "sm")}
-            <div className="mt-2 text-xs font-semibold text-gray-900 leading-tight break-words w-full">
-              {getTeamDisplayName(game.awayTeam)}
-            </div>
-          </div>
+          ) : (
+            <>
+              <div className="text-lg font-bold text-gray-600">vs</div>
+              <div className="text-sm text-gray-500">{formatTime(game.scheduledDate)}</div>
+            </>
+          )}
         </div>
 
-        <div className="mt-3 text-xs text-gray-500 text-center">
-          {game.week ? `Semana ${game.week}` : "Sin semana"} · {getDivisionName(game)}
-          {game.round ? ` · ${game.round}` : ""}
+        <div className="min-w-0 text-center">
+          <div className="mb-2 flex justify-center">{renderGameTeamAvatar(game.awayTeam, "sm")}</div>
+          <div className="truncate text-sm font-bold text-gray-900">{getTeamDisplayName(game.awayTeam)}</div>
         </div>
       </div>
 
-      <div className="hidden sm:block">
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex-1">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center space-x-2">
-                {getGameStatusTag(game.status)}
-                <span className="text-sm text-gray-500">
-                  {game.week ? `Semana ${game.week}` : "Sin semana"} - {getDivisionName(game)}
-                  {game.round ? ` - ${game.round}` : ""}
-                </span>
-              </div>
-              <div className="text-sm text-gray-500">{formatDate(game.scheduledDate)}</div>
-            </div>
-
-            <div className="flex items-center justify-center space-x-8 mb-4">
-              <div className="flex items-center space-x-3 flex-1 justify-end">
-                <div className="text-right">
-                  <div className="font-semibold text-gray-900">{getTeamDisplayName(game.homeTeam)}</div>
-                  {typeof game.homeTeam !== "string" && game.homeTeam && !game.homeTeam.logo && game.homeTeam.shortName && (
-                    <div className="text-sm text-gray-500">{game.homeTeam.shortName}</div>
-                  )}
-                </div>
-                {renderGameTeamAvatar(game.homeTeam, "md")}
-              </div>
-
-              <div className="flex items-center space-x-4">
-                {game.status === "completed" || game.status === "in_progress" ? (
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-gray-900">
-                      {game.score.home.total} - {game.score.away.total}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="text-center">
-                    <div className="text-lg font-medium text-gray-500">vs</div>
-                    <div className="text-sm text-gray-400">{formatTime(game.scheduledDate)}</div>
-                  </div>
-                )}
-              </div>
-
-              <div className="flex items-center space-x-3 flex-1">
-                {renderGameTeamAvatar(game.awayTeam, "md")}
-                <div>
-                  <div className="font-semibold text-gray-900">{getTeamDisplayName(game.awayTeam)}</div>
-                  {typeof game.awayTeam !== "string" && game.awayTeam && !game.awayTeam.logo && game.awayTeam.shortName && (
-                    <div className="text-sm text-gray-500">{game.awayTeam.shortName}</div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-center text-sm text-gray-500">
-              <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              {game.venue.name}, {game.venue.address}
-            </div>
-          </div>
-        </div>
+      <div className="mt-4 truncate text-center text-xs text-gray-500">
+        {game.week ? `Semana ${game.week}` : "Sin semana"} · {getDivisionName(game)}
+        {game.round ? ` · ${game.round}` : ""}
       </div>
     </Link>
   );
@@ -1203,7 +1117,7 @@ export default function TeamViewerPage() {
                   </div>
 
                   {upcomingGames.length > 0 ? (
-                    <div className="space-y-4">{upcomingGames.map(renderGameCard)}</div>
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{upcomingGames.map(renderGameCard)}</div>
                   ) : (
                     <div className="rounded-lg bg-gray-50 px-4 py-10 text-center">
                       <h4 className="text-sm font-medium text-gray-900">No hay próximos partidos</h4>
@@ -1223,7 +1137,7 @@ export default function TeamViewerPage() {
                   </div>
 
                   {previousGames.length > 0 ? (
-                    <div className="space-y-4">{previousGames.map(renderGameCard)}</div>
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{previousGames.map(renderGameCard)}</div>
                   ) : (
                     <div className="rounded-lg bg-gray-50 px-4 py-10 text-center">
                       <h4 className="text-sm font-medium text-gray-900">No hay partidos anteriores</h4>

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -155,13 +155,31 @@ interface GameEvent {
   yards?: number;
 }
 
+interface GameTeam {
+  _id: string;
+  name: string;
+  shortName?: string;
+  logo?: string;
+  colors: {
+    primary: string;
+    secondary?: string;
+  };
+}
+
 interface TeamGame {
   _id: string;
   status: "scheduled" | "in_progress" | "completed" | "postponed" | "cancelled";
-  homeTeam: string | { _id: string } | null;
-  awayTeam: string | { _id: string } | null;
+  scheduledDate: string;
+  week?: number;
+  round?: string;
+  homeTeam: string | GameTeam | null;
+  awayTeam: string | GameTeam | null;
   tournament: string | { _id: string; name?: string; year?: number };
   division: string | { _id: string; name?: string; category?: string };
+  venue: {
+    name: string;
+    address: string;
+  };
   score: {
     home: { total: number };
     away: { total: number };
@@ -315,10 +333,11 @@ export default function TeamViewerPage() {
 
   const [team, setTeam] = useState<Team | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
+  const [teamGames, setTeamGames] = useState<TeamGame[]>([]);
   const [teamStats, setTeamStats] = useState<TeamStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"info" | "roster" | "stats">("info");
+  const [activeTab, setActiveTab] = useState<"info" | "roster" | "games" | "stats">("info");
 
   const fetchPlayers = useCallback(async () => {
     try {
@@ -365,14 +384,19 @@ export default function TeamViewerPage() {
           const gamesData = await gamesResponse.json();
 
           if (gamesData.success) {
-            setTeamStats(deriveTeamStatsFromGames(loadedTeam, gamesData.data || []));
+            const loadedGames = (gamesData.data || []) as TeamGame[];
+            setTeamGames(loadedGames);
+            setTeamStats(deriveTeamStatsFromGames(loadedTeam, loadedGames));
           } else if (statsData.success && statsData.data.length > 0) {
+            setTeamGames([]);
             setTeamStats(statsData.data[0]);
           } else {
+            setTeamGames([]);
             setTeamStats(emptyTeamStats(loadedTeam));
           }
         } catch (statsError) {
           console.log("Stats not available:", statsError);
+          setTeamGames([]);
           setTeamStats(emptyTeamStats(loadedTeam));
         }
       } catch {
@@ -399,6 +423,201 @@ export default function TeamViewerPage() {
     const { label, type } = statusMap[status] || { label: status, type: "info" as const };
     return <Tag label={label} type={type} />;
   };
+
+  const getGameStatusTag = (status: TeamGame["status"]) => {
+    const statusMap: Record<TeamGame["status"], { label: string; type: "info" | "warning" | "success" | "error" }> = {
+      scheduled: { label: "Programado", type: "info" },
+      in_progress: { label: "En Curso", type: "success" },
+      completed: { label: "Completado", type: "success" },
+      postponed: { label: "Pospuesto", type: "warning" },
+      cancelled: { label: "Cancelado", type: "error" },
+    };
+
+    const { label, type } = statusMap[status];
+    return <Tag label={label} type={type} />;
+  };
+
+  const getTeamDisplayName = (gameTeam: TeamGame["homeTeam"]) => {
+    if (!gameTeam || typeof gameTeam === "string") return "TBD";
+    return gameTeam.name;
+  };
+
+  const getTeamAvatarFallback = (gameTeam: TeamGame["homeTeam"]) => {
+    if (!gameTeam || typeof gameTeam === "string") return "TBD";
+    return (gameTeam.shortName || gameTeam.name.substring(0, 2)).toUpperCase();
+  };
+
+  const renderGameTeamAvatar = (gameTeam: TeamGame["homeTeam"], size: "sm" | "md") => (
+    <Avatar
+      imageUrl={typeof gameTeam === "string" ? undefined : gameTeam?.logo}
+      alt={getTeamDisplayName(gameTeam)}
+      fallback={getTeamAvatarFallback(gameTeam)}
+      backgroundColor={typeof gameTeam === "string" ? "#9CA3AF" : gameTeam?.colors.primary || "#9CA3AF"}
+      size={size}
+      fallbackClassName={size === "sm" ? "text-xs" : "text-sm"}
+    />
+  );
+
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleDateString("es-ES", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  };
+
+  const formatTime = (date: string) => {
+    return new Date(date).toLocaleTimeString("es-ES", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const formatDateTimeCompact = (date: string) => {
+    const parsedDate = new Date(date);
+    const dayMonth = parsedDate.toLocaleDateString("es-ES", {
+      day: "2-digit",
+      month: "short",
+    });
+
+    const hour = parsedDate.toLocaleTimeString("es-ES", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    return `${dayMonth} · ${hour}`;
+  };
+
+  const getDivisionName = (game: TeamGame) => {
+    return typeof game.division === "string" ? "División" : game.division.name || "División";
+  };
+
+  const renderGameCard = (game: TeamGame) => (
+    <Link
+      key={game._id}
+      href={`/games/${game._id}`}
+      className="block rounded-lg bg-white p-4 shadow-md transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 sm:p-6"
+      aria-label={`Ver match ${getTeamDisplayName(game.homeTeam)} vs ${getTeamDisplayName(game.awayTeam)}`}
+    >
+      <div className="sm:hidden">
+        <div className="flex items-start justify-between gap-3">
+          <div className="text-sm font-medium text-gray-700 break-words">{game.venue.name}</div>
+          <div className="text-xs text-gray-500 whitespace-nowrap">{formatDateTimeCompact(game.scheduledDate)}</div>
+        </div>
+
+        <div className="mt-1 text-xs text-gray-500 break-words">{game.venue.address}</div>
+
+        <div className="mt-3 flex justify-center">{getGameStatusTag(game.status)}</div>
+
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <div className="w-[36%] flex flex-col items-center text-center">
+            {renderGameTeamAvatar(game.homeTeam, "sm")}
+            <div className="mt-2 text-xs font-semibold text-gray-900 leading-tight break-words w-full">
+              {getTeamDisplayName(game.homeTeam)}
+            </div>
+          </div>
+
+          <div className="w-[28%] text-center">
+            {game.status === "completed" || game.status === "in_progress" ? (
+              <div className="text-4xl font-bold text-blue-900 leading-none">
+                {game.score.home.total}:{game.score.away.total}
+              </div>
+            ) : (
+              <div>
+                <div className="text-base font-semibold text-gray-500">vs</div>
+                <div className="text-xs text-gray-400">{formatTime(game.scheduledDate)}</div>
+              </div>
+            )}
+          </div>
+
+          <div className="w-[36%] flex flex-col items-center text-center">
+            {renderGameTeamAvatar(game.awayTeam, "sm")}
+            <div className="mt-2 text-xs font-semibold text-gray-900 leading-tight break-words w-full">
+              {getTeamDisplayName(game.awayTeam)}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 text-xs text-gray-500 text-center">
+          {game.week ? `Semana ${game.week}` : "Sin semana"} · {getDivisionName(game)}
+          {game.round ? ` · ${game.round}` : ""}
+        </div>
+      </div>
+
+      <div className="hidden sm:block">
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex-1">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-2">
+                {getGameStatusTag(game.status)}
+                <span className="text-sm text-gray-500">
+                  {game.week ? `Semana ${game.week}` : "Sin semana"} - {getDivisionName(game)}
+                  {game.round ? ` - ${game.round}` : ""}
+                </span>
+              </div>
+              <div className="text-sm text-gray-500">{formatDate(game.scheduledDate)}</div>
+            </div>
+
+            <div className="flex items-center justify-center space-x-8 mb-4">
+              <div className="flex items-center space-x-3 flex-1 justify-end">
+                <div className="text-right">
+                  <div className="font-semibold text-gray-900">{getTeamDisplayName(game.homeTeam)}</div>
+                  {typeof game.homeTeam !== "string" && game.homeTeam && !game.homeTeam.logo && game.homeTeam.shortName && (
+                    <div className="text-sm text-gray-500">{game.homeTeam.shortName}</div>
+                  )}
+                </div>
+                {renderGameTeamAvatar(game.homeTeam, "md")}
+              </div>
+
+              <div className="flex items-center space-x-4">
+                {game.status === "completed" || game.status === "in_progress" ? (
+                  <div className="text-center">
+                    <div className="text-2xl font-bold text-gray-900">
+                      {game.score.home.total} - {game.score.away.total}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center">
+                    <div className="text-lg font-medium text-gray-500">vs</div>
+                    <div className="text-sm text-gray-400">{formatTime(game.scheduledDate)}</div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex items-center space-x-3 flex-1">
+                {renderGameTeamAvatar(game.awayTeam, "md")}
+                <div>
+                  <div className="font-semibold text-gray-900">{getTeamDisplayName(game.awayTeam)}</div>
+                  {typeof game.awayTeam !== "string" && game.awayTeam && !game.awayTeam.logo && game.awayTeam.shortName && (
+                    <div className="text-sm text-gray-500">{game.awayTeam.shortName}</div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-center text-sm text-gray-500">
+              <svg className="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              {game.venue.name}, {game.venue.address}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
 
   const calculateWinPercentage = (stats: TeamStats) => {
     const totalGames = stats.wins + stats.losses + stats.ties;
@@ -442,6 +661,13 @@ export default function TeamViewerPage() {
   }
 
   const hasHeaderImage = Boolean(team.backgroundImage);
+  const now = Date.now();
+  const upcomingGames = [...teamGames]
+    .filter((game) => game.status !== "completed" && new Date(game.scheduledDate).getTime() >= now)
+    .sort((left, right) => new Date(left.scheduledDate).getTime() - new Date(right.scheduledDate).getTime());
+  const previousGames = [...teamGames]
+    .filter((game) => game.status === "completed" || new Date(game.scheduledDate).getTime() < now)
+    .sort((left, right) => new Date(right.scheduledDate).getTime() - new Date(left.scheduledDate).getTime());
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -633,6 +859,16 @@ export default function TeamViewerPage() {
                 }`}
               >
                 Plantilla ({players.length})
+              </button>
+              <button
+                onClick={() => setActiveTab("games")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "games"
+                    ? "border-green-500 text-green-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                }`}
+              >
+                Partidos ({teamGames.length})
               </button>
               <button
                 onClick={() => setActiveTab("stats")}
@@ -952,6 +1188,51 @@ export default function TeamViewerPage() {
                     </table>
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Games Tab */}
+            {activeTab === "games" && (
+              <div className="space-y-8">
+                <section>
+                  <div className="mb-4">
+                    <h3 className="text-lg font-medium text-gray-900">Próximos partidos</h3>
+                    <p className="mt-1 text-sm text-gray-700">
+                      Partidos programados o en curso para este equipo.
+                    </p>
+                  </div>
+
+                  {upcomingGames.length > 0 ? (
+                    <div className="space-y-4">{upcomingGames.map(renderGameCard)}</div>
+                  ) : (
+                    <div className="rounded-lg bg-gray-50 px-4 py-10 text-center">
+                      <h4 className="text-sm font-medium text-gray-900">No hay próximos partidos</h4>
+                      <p className="mt-1 text-sm text-gray-500">
+                        Cuando se programen partidos para este equipo, aparecerán acá.
+                      </p>
+                    </div>
+                  )}
+                </section>
+
+                <section>
+                  <div className="mb-4">
+                    <h3 className="text-lg font-medium text-gray-900">Historial de partidos</h3>
+                    <p className="mt-1 text-sm text-gray-700">
+                      Partidos anteriores y resultados registrados.
+                    </p>
+                  </div>
+
+                  {previousGames.length > 0 ? (
+                    <div className="space-y-4">{previousGames.map(renderGameCard)}</div>
+                  ) : (
+                    <div className="rounded-lg bg-gray-50 px-4 py-10 text-center">
+                      <h4 className="text-sm font-medium text-gray-900">No hay partidos anteriores</h4>
+                      <p className="mt-1 text-sm text-gray-500">
+                        El historial aparecerá cuando este equipo haya jugado partidos.
+                      </p>
+                    </div>
+                  )}
+                </section>
               </div>
             )}
 

--- a/src/repositories/mongodb/MongoGameRepository.ts
+++ b/src/repositories/mongodb/MongoGameRepository.ts
@@ -90,6 +90,10 @@ export class MongoGameRepository implements IGameRepository {
     })
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();

--- a/src/repositories/mongodb/MongoGameRepository.ts
+++ b/src/repositories/mongodb/MongoGameRepository.ts
@@ -25,6 +25,8 @@ export class MongoGameRepository implements IGameRepository {
     const docs = await GameModel.find(filters || {})
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
       .populate("presentPlayers.home")
       .populate("presentPlayers.away")
       .populate("events.team")
@@ -77,6 +79,10 @@ export class MongoGameRepository implements IGameRepository {
     const docs = await GameModel.find({ tournament: tournamentId })
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();
@@ -102,7 +108,14 @@ export class MongoGameRepository implements IGameRepository {
 
   async findByStatus(status: GameStatus): Promise<Game[]> {
     await connectToDatabase();
-    const docs = await GameModel.find({ status }).populate("homeTeam").populate("awayTeam").exec();
+    const docs = await GameModel.find({ status })
+      .populate("homeTeam")
+      .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
+      .exec();
     return docs;
   }
 
@@ -115,6 +128,8 @@ export class MongoGameRepository implements IGameRepository {
     })
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
       .exec();
     return docs;
   }
@@ -124,6 +139,10 @@ export class MongoGameRepository implements IGameRepository {
     const docs = await GameModel.find({ division: divisionId })
       .populate("homeTeam")
       .populate("awayTeam")
+      .populate("tournament")
+      .populate("division")
+      .populate("presentPlayers.home")
+      .populate("presentPlayers.away")
       .populate("events.team")
       .populate("events.player")
       .exec();


### PR DESCRIPTION
This pull request introduces several improvements to how game and team data are structured, displayed, and fetched throughout the application. The main changes include enhancing the data models for tournaments and divisions, updating the UI to provide a richer team page with a new "Games" tab, and ensuring that more detailed information is available when rendering games and teams. These changes improve both the backend data consistency and the frontend user experience.

**Data Model and DTO Enhancements:**

* The `GameResponseDto` and related mapping functions now support returning detailed objects for `tournament` and `division` (with fields like `name`, `year`, and `category`) instead of just IDs, enabling richer data in the frontend. [[1]](diffhunk://#diff-9d9c4489b93797a2c238e431b1da7a5852484a591a46dd16d1fe9fbf828db927L8-R21) [[2]](diffhunk://#diff-060741612f169a5085fb74a64eedd9a45828241d63aa9a028400262c6be5cda3R9-R10) [[3]](diffhunk://#diff-060741612f169a5085fb74a64eedd9a45828241d63aa9a028400262c6be5cda3L46-R49) [[4]](diffhunk://#diff-060741612f169a5085fb74a64eedd9a45828241d63aa9a028400262c6be5cda3R75-R98)
* The `MongoGameRepository` now populates `tournament` and `division` references (as well as teams and present players) in all relevant queries, ensuring that game data includes all necessary related information for the UI. [[1]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65R28-R29) [[2]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65R82-R85) [[3]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65R99-R102) [[4]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65L101-R118) [[5]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65R131-R132) [[6]](diffhunk://#diff-d6ecf04d2fde341668fb5910e4d3794a06be65ab3359d58951ee779e2c820c65R142-R145)

**Frontend UI Improvements:**

* The team viewer page (`src/app/teams/[id]/page.tsx`) now includes a new "Games" tab, which displays upcoming and previous games for the team, with improved cards showing venue, time, status, opponents, and scores. Utility functions for formatting and display have been added to support this. ([src/app/teams/[id]/page.tsxR336-R340](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR336-R340), [src/app/teams/[id]/page.tsxL368-R399](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aL368-R399), [src/app/teams/[id]/page.tsxR427-R543](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR427-R543), [src/app/teams/[id]/page.tsxR586-R592](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR586-R592), [src/app/teams/[id]/page.tsxR785-R794](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR785-R794), [src/app/teams/[id]/page.tsxR1116-R1160](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR1116-R1160))
* Division display names are now more user-friendly, showing the category label ("Masculino", "Femenino", "Mixto") when available, both in the games list and team page. [[1]](diffhunk://#diff-bb7da0bbe123ff7e4af0183f283cb62c91dd325c31b0dfb0157e8ab634ec3315R142-R153) [[2]](diffhunk://#diff-bb7da0bbe123ff7e4af0183f283cb62c91dd325c31b0dfb0157e8ab634ec3315L1025-R1037) [[3]](diffhunk://#diff-bb7da0bbe123ff7e4af0183f283cb62c91dd325c31b0dfb0157e8ab634ec3315L1038-R1050) [src/app/teams/[id]/page.tsxR427-R543](diffhunk://#diff-bdb46e44471649b2dfdaa5e12c8098817e94bb4b7dde2c910e0803013f22de6aR427-R543))

These updates provide a more informative and visually appealing experience for users viewing team and game information, and ensure that the backend delivers all required data for these features.